### PR TITLE
Update Case Study5 exercise 1 to 2.md

### DIFF
--- a/Instructions/Labs/Case Study5 exercise 1 to 2.md
+++ b/Instructions/Labs/Case Study5 exercise 1 to 2.md
@@ -167,7 +167,7 @@ Would you assist the planning manager in doing the following?
 
 9.  Select **Item Allocation Keys.**
 
-10. Select **Apples** under the **Unassigned Item Allocation Keys** box, then
+10. Select **Audio** under the **Unassigned Item Allocation Keys** box, then
     select **\>** to move it to the **Assigned Allocation Keys** box.
 
 ### Run an intercompany master plan


### PR DESCRIPTION
2	Assign item allocation key	10	wrong item	There is no item group called Apples in USMF or DEMF. I recommend using Audio as they exist in both companies.

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-