### PR TITLE
Update Case Study5 exercise 1 to 2.md

### DIFF
--- a/Instructions/Labs/Case Study5 exercise 1 to 2.md
+++ b/Instructions/Labs/Case Study5 exercise 1 to 2.md
@@ -180,7 +180,7 @@ Would you assist the planning manager in doing the following?
 
 3.  Open **Master planning** \> **Run** \> **Intercompany master planning**.
 
-4.  Select **60** for **Intercompany planning group**.
+4.  Select **Intercompa** for **Intercompany planning group**.
 
 5.  Select **2** for **Number of intercompany planning iterations**.
 


### PR DESCRIPTION
2	Run an intercompany master plan	4	Incorrect instruction	In this step it says to select 60, but in the previous task, we are to create Intercompa. Change the instruction to match Intercompa

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-