### PR TITLE
Backfill missing lab metadata (11 files)

### DIFF
--- a/Instructions/Labs/Case Study 0 Intro.md
+++ b/Instructions/Labs/Case Study 0 Intro.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Case study instructions'
-    module: 'Module 0: Supply chain management case studies'
+  title: Case study instructions
+  module: 'Module 0: Supply chain management case studies'
+  description: managers and product designers in our scenarios.
+  duration: 30 minutes
+  level: 100
+  islab: true
 ---
 
 Case study instructions

--- a/Instructions/Labs/Case Study 0 Intro.md
+++ b/Instructions/Labs/Case Study 0 Intro.md
@@ -3,7 +3,7 @@ lab:
   title: Case study instructions
   module: 'Module 0: Supply chain management case studies'
   description: managers and product designers in our scenarios.
-  duration: 30 minutes
+  duration: 2 minutes
   level: 100
   islab: true
 ---

--- a/Instructions/Labs/Case Study 1 Prod Mgmt EX 1 to 4.md
+++ b/Instructions/Labs/Case Study 1 Prod Mgmt EX 1 to 4.md
@@ -2,9 +2,9 @@
 lab:
   title: Case study 1 Product information management
   module: 'Module 1: Implement product information management'
-  description: 'Some new products are introduced by USMF and must be added to the new warehouse. As supply chain manager, you will have to create 2 new products:'
+  description: 'New products are introduced by USMF and must be added to the new warehouse. As supply chain manager, you will have to create 2 new products:'
   duration: 30 minutes
-  level: 100
+  level: 200
   islab: true
 ---
 

--- a/Instructions/Labs/Case Study 1 Prod Mgmt EX 1 to 4.md
+++ b/Instructions/Labs/Case Study 1 Prod Mgmt EX 1 to 4.md
@@ -3,7 +3,7 @@ lab:
   title: Case study 1 Product information management
   module: 'Module 1: Implement product information management'
   description: 'New products are introduced by USMF and must be added to the new warehouse. As supply chain manager, you will have to create 2 new products:'
-  duration: 30 minutes
+  duration: 10 minutes
   level: 200
   islab: true
 ---

--- a/Instructions/Labs/Case Study 1 Prod Mgmt EX 1 to 4.md
+++ b/Instructions/Labs/Case Study 1 Prod Mgmt EX 1 to 4.md
@@ -3,7 +3,7 @@ lab:
   title: Case study 1 Product information management
   module: 'Module 1: Implement product information management'
   description: 'Some new products are introduced by USMF and must be added to the new warehouse. As supply chain manager, you will have to create 2 new products:'
-  duration: 146 minutes
+  duration: 30 minutes
   level: 100
   islab: true
 ---

--- a/Instructions/Labs/Case Study 1 Prod Mgmt EX 1 to 4.md
+++ b/Instructions/Labs/Case Study 1 Prod Mgmt EX 1 to 4.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Case study 1 Product information management'
-    module: 'Module 1: Implement product information management'
+  title: Case study 1 Product information management
+  module: 'Module 1: Implement product information management'
+  description: 'Some new products are introduced by USMF and must be added to the new warehouse. As supply chain manager, you will have to create 2 new products:'
+  duration: 146 minutes
+  level: 100
+  islab: true
 ---
 
 Case study 1 Product information management

--- a/Instructions/Labs/Case Study 2A Inventory EX 1 to 4.md
+++ b/Instructions/Labs/Case Study 2A Inventory EX 1 to 4.md
@@ -3,7 +3,7 @@ lab:
   title: Case study 2A Inventory management
   module: 'Module 2: Implement inventory and asset management'
   description: You will also need to adjust the stock levels of products in the warehouse.
-  duration: 138 minutes
+  duration: 40 minutes
   level: 200
   islab: true
 ---

--- a/Instructions/Labs/Case Study 2A Inventory EX 1 to 4.md
+++ b/Instructions/Labs/Case Study 2A Inventory EX 1 to 4.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Case study 2A Inventory management'
-    module: 'Module 2: Implement inventory and asset management'
+  title: Case study 2A Inventory management
+  module: 'Module 2: Implement inventory and asset management'
+  description: You will also need to adjust the stock levels of products in the warehouse.
+  duration: 138 minutes
+  level: 200
+  islab: true
 ---
 
 Case study 2A Inventory management

--- a/Instructions/Labs/Case Study 2B Quality EX 1 to 5.md
+++ b/Instructions/Labs/Case Study 2B Quality EX 1 to 5.md
@@ -3,8 +3,8 @@ lab:
   title: Case study 2B Quality control and quality management
   module: 'Module 2: Implement inventory and asset management'
   description: 'You will need to define several conditions to work with non-conformance: problems and diagnostic types, operations, quality charges, and quarantine zones.'
-  duration: 162 minutes
-  level: 100
+  duration: 40 minutes
+  level: 200
   islab: true
 ---
 

--- a/Instructions/Labs/Case Study 2B Quality EX 1 to 5.md
+++ b/Instructions/Labs/Case Study 2B Quality EX 1 to 5.md
@@ -1,8 +1,13 @@
 ---
 lab:
-    title: 'Case study 2B Quality control and quality management'
-    module: 'Module 2: Implement inventory and asset management'
+  title: Case study 2B Quality control and quality management
+  module: 'Module 2: Implement inventory and asset management'
+  description: 'You will need to define several conditions to work with non-conformance: problems and diagnostic types, operations, quality charges, and quarantine zones.'
+  duration: 162 minutes
+  level: 100
+  islab: true
 ---
+
 Case study 2B Quality control and quality management
 ===================================================
 

--- a/Instructions/Labs/Case Study 2C Asset Mgmt EX 1 to 5.md
+++ b/Instructions/Labs/Case Study 2C Asset Mgmt EX 1 to 5.md
@@ -1,8 +1,13 @@
 ---
 lab:
-    title: 'Case study 2C Asset management'
-    module: 'Module 2: Implement inventory and asset management'
+  title: Case study 2C Asset management
+  module: 'Module 2: Implement inventory and asset management'
+  description: In this case study, you will work with the Asset Management module to set up assets, functional locations, and maintenance requests for Munson's Pickles and Preserves Farm. You will create asset types, condition assessment templates, service levels, workers, and functional location lifecycle states and models.
+  duration: 182 minutes
+  level: 100
+  islab: true
 ---
+
 Case study 2C Asset management
 =================================
 

--- a/Instructions/Labs/Case Study 2C Asset Mgmt EX 1 to 5.md
+++ b/Instructions/Labs/Case Study 2C Asset Mgmt EX 1 to 5.md
@@ -3,8 +3,8 @@ lab:
   title: Case study 2C Asset management
   module: 'Module 2: Implement inventory and asset management'
   description: In this case study, you will work with the Asset Management module to set up assets, functional locations, and maintenance requests for Munson's Pickles and Preserves Farm. You will create asset types, condition assessment templates, service levels, workers, and functional location lifecycle states and models.
-  duration: 182 minutes
-  level: 100
+  duration: 50 minutes
+  level: 200
   islab: true
 ---
 

--- a/Instructions/Labs/Case Study 3A Proc EX 1 to 10.md
+++ b/Instructions/Labs/Case Study 3A Proc EX 1 to 10.md
@@ -3,7 +3,7 @@ lab:
   title: Case study 3A Procurement and sourcing
   module: 'Module 3: Implement and manage supply chain processes '
   description: The employee must identify a vendor for the request and the quantity required. The employee do not know the actual part number, so you will use a procurement category instead.
-  duration: 176 minutes
+  duration: 30 minutes
   level: 200
   islab: true
 ---

--- a/Instructions/Labs/Case Study 3A Proc EX 1 to 10.md
+++ b/Instructions/Labs/Case Study 3A Proc EX 1 to 10.md
@@ -1,8 +1,13 @@
 ---
 lab:
-    title: 'Case study 3A Procurement and sourcing'
-    module: 'Module 3: Implement and manage supply chain processes '
+  title: Case study 3A Procurement and sourcing
+  module: 'Module 3: Implement and manage supply chain processes '
+  description: The employee must identify a vendor for the request and the quantity required. The employee do not know the actual part number, so you will use a procurement category instead.
+  duration: 176 minutes
+  level: 200
+  islab: true
 ---
+
 Case study 3A Procurement and sourcing
 ======================================
 

--- a/Instructions/Labs/Case Study 3B Landed cost EX 1 to 3.md
+++ b/Instructions/Labs/Case Study 3B Landed cost EX 1 to 3.md
@@ -3,8 +3,8 @@ lab:
   title: Case study 3B Landed cost
   module: 'Module 3: Implement and manage supply chain processes'
   description: Case study 3B Landed cost =================================
-  duration: 110 minutes
-  level: 100
+  duration: 15 minutes
+  level: 200
   islab: true
 ---
 

--- a/Instructions/Labs/Case Study 3B Landed cost EX 1 to 3.md
+++ b/Instructions/Labs/Case Study 3B Landed cost EX 1 to 3.md
@@ -1,8 +1,13 @@
 ---
 lab:
-    title: 'Case study 3B Landed cost'
-    module: 'Module 3: Implement and manage supply chain processes'
+  title: Case study 3B Landed cost
+  module: 'Module 3: Implement and manage supply chain processes'
+  description: Case study 3B Landed cost =================================
+  duration: 110 minutes
+  level: 100
+  islab: true
 ---
+
 Case study 3B Landed cost
 =================================
 

--- a/Instructions/Labs/Case Study 3C Sales EX 1 to 4.md
+++ b/Instructions/Labs/Case Study 3C Sales EX 1 to 4.md
@@ -1,8 +1,13 @@
 ---
 lab:
-    title: 'Case study 3C Sales and marketing'
-    module: 'Module 3: Implement and manage supply chain processes'
+  title: Case study 3C Sales and marketing
+  module: 'Module 3: Implement and manage supply chain processes'
+  description: You will need to help her to create a sales order for customer US-013, who is requesting 2 units of item D0001. You will proceed with all of the sales order process until the invoicing step. Then you will check the registered sales commission on the sales order.
+  duration: 160 minutes
+  level: 100
+  islab: true
 ---
+
 Case study 3C Sales and marketing
 =================================
 

--- a/Instructions/Labs/Case Study 3C Sales EX 1 to 4.md
+++ b/Instructions/Labs/Case Study 3C Sales EX 1 to 4.md
@@ -3,8 +3,8 @@ lab:
   title: Case study 3C Sales and marketing
   module: 'Module 3: Implement and manage supply chain processes'
   description: You will need to help her to create a sales order for customer US-013, who is requesting 2 units of item D0001. You will proceed with all of the sales order process until the invoicing step. Then you will check the registered sales commission on the sales order.
-  duration: 160 minutes
-  level: 100
+  duration: 30 minutes
+  level: 200
   islab: true
 ---
 

--- a/Instructions/Labs/Case Study 4A WMS EX 1 to 14.md
+++ b/Instructions/Labs/Case Study 4A WMS EX 1 to 14.md
@@ -1,8 +1,13 @@
 ---
 lab:
-    title: 'Case study 4A Warehouse management'
-    module: 'Module 4: Implement warehouse management and transportation management'
+  title: Case study 4A Warehouse management
+  module: 'Module 4: Implement warehouse management and transportation management'
+  description: You must set up two new disposition codes. The first will be called “Ready,” which will be Available, and the second will be called “Not Ready,” which will be blocked for use with warehouse management. Next, you will configure a new inbound location directive that will receive goods to the warehouse, and another one that will put away goods in bulk locations.
+  duration: 190 minutes
+  level: 200
+  islab: true
 ---
+
 Case study 4A Warehouse management
 ===============================================================
 

--- a/Instructions/Labs/Case Study 4A WMS EX 1 to 14.md
+++ b/Instructions/Labs/Case Study 4A WMS EX 1 to 14.md
@@ -3,7 +3,7 @@ lab:
   title: Case study 4A Warehouse management
   module: 'Module 4: Implement warehouse management and transportation management'
   description: You must set up two new disposition codes. The first will be called “Ready,” which will be Available, and the second will be called “Not Ready,” which will be blocked for use with warehouse management. Next, you will configure a new inbound location directive that will receive goods to the warehouse, and another one that will put away goods in bulk locations.
-  duration: 190 minutes
+  duration: 60 minutes
   level: 200
   islab: true
 ---

--- a/Instructions/Labs/Case Study 4B Transpo EX 1 to 6.md
+++ b/Instructions/Labs/Case Study 4B Transpo EX 1 to 6.md
@@ -3,8 +3,8 @@ lab:
   title: Case study 3B Transportation management
   module: 'Module 4: Implement warehouse management and transportation management'
   description: You have been asked to create a new purchase order for 10 mini-speakers from the Ade Supply Company. After creating the purchase order, you will need to create an inbound shipment and then rate shop for the inbound load to find the cheapest transportation rate.
-  duration: 190 minutes
-  level: 100
+  duration: 90 minutes
+  level: 200
   islab: true
 ---
 

--- a/Instructions/Labs/Case Study 4B Transpo EX 1 to 6.md
+++ b/Instructions/Labs/Case Study 4B Transpo EX 1 to 6.md
@@ -1,8 +1,13 @@
 ---
 lab:
-    title: 'Case study 3B Transportation management'
-    module: 'Module 4: Implement warehouse management and transportation management'
+  title: Case study 3B Transportation management
+  module: 'Module 4: Implement warehouse management and transportation management'
+  description: You have been asked to create a new purchase order for 10 mini-speakers from the Ade Supply Company. After creating the purchase order, you will need to create an inbound shipment and then rate shop for the inbound load to find the cheapest transportation rate.
+  duration: 190 minutes
+  level: 100
+  islab: true
 ---
+
 Case study 3B Transportation management
 ===============================================================
 

--- a/Instructions/Labs/Case Study 5 Master planning EX 1 to 2.md
+++ b/Instructions/Labs/Case Study 5 Master planning EX 1 to 2.md
@@ -1,8 +1,13 @@
 ---
 lab:
-    title: 'Case study 5 Master planning'
-    module: 'Module 5: Implement master planning '
+  title: Case study 5 Master planning
+  module: 'Module 5: Implement master planning '
+  description: Case study 5 Master planning ============================
+  duration: 130 minutes
+  level: 100
+  islab: true
 ---
+
 Case study 5 Master planning
 ============================
 

--- a/Instructions/Labs/Case Study 5 Master planning EX 1 to 2.md
+++ b/Instructions/Labs/Case Study 5 Master planning EX 1 to 2.md
@@ -3,8 +3,8 @@ lab:
   title: Case study 5 Master planning
   module: 'Module 5: Implement master planning '
   description: Case study 5 Master planning ============================
-  duration: 130 minutes
-  level: 100
+  duration: 20 minutes
+  level: 200
   islab: true
 ---
 


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 11

- `Instructions/Labs/Case Study 0 Intro.md` (description,duration,level,islab)
- `Instructions/Labs/Case Study 1 Prod Mgmt EX 1 to 4.md` (description,duration,level,islab)
- `Instructions/Labs/Case Study 2A Inventory EX 1 to 4.md` (description,duration,level,islab)
- `Instructions/Labs/Case Study 2B Quality EX 1 to 5.md` (description,duration,level,islab)
- `Instructions/Labs/Case Study 2C Asset Mgmt EX 1 to 5.md` (description,duration,level,islab)
- `Instructions/Labs/Case Study 3A Proc EX 1 to 10.md` (description,duration,level,islab)
- `Instructions/Labs/Case Study 3B Landed cost EX 1 to 3.md` (description,duration,level,islab)
- `Instructions/Labs/Case Study 3C Sales EX 1 to 4.md` (description,duration,level,islab)
- `Instructions/Labs/Case Study 4A WMS EX 1 to 14.md` (description,duration,level,islab)
- `Instructions/Labs/Case Study 4B Transpo EX 1 to 6.md` (description,duration,level,islab)
- `Instructions/Labs/Case Study 5 Master planning EX 1 to 2.md` (description,duration,level,islab)
